### PR TITLE
Fix encoded URL breaks event time converter

### DIFF
--- a/pages/event-time.html
+++ b/pages/event-time.html
@@ -245,7 +245,7 @@ tag: tool
 
         let hash = null;
         if(window.location.hash.length > 2){
-            hash = window.location.hash.substring(1);
+            hash = decodeURIComponent(window.location.hash.substring(1));
         }
 
         console.log(hash);


### PR DESCRIPTION
This fixes a bug where using an encoded URL breaks the event time converter. This bug can be reproduced by creating a new event and posting the URL into a Discord chat (discord.com). Discord will automatically replace characters like "|" to their encoded value, i.e. `%7C`.

For example, the following URL 1 (omitting host and protocol) will be escaped to URL 2.

1. https://siege.dangeraspect.xyz/event-time#Test%20Event|2021-01-17|Europe/Berlin
2. https://siege.dangeraspect.xyz/event-time#Test%20Event%7C2021-01-17%7CEurope/Berlin

Opening URL 2 results shows the error message “Error encountered retrieving data.”

The bug is fixed by decoding the URI component (the hash) using `decodeURIComponent` which is supported in [most browsers](caniuse).

[caniuse]: https://caniuse.com/mdn-javascript_builtins_decodeuricomponent

## Screenshots

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/28510368/104792686-8522d080-579f-11eb-8a79-6b17d222015f.png) | ![image](https://user-images.githubusercontent.com/28510368/104792734-b4394200-579f-11eb-961b-5c97f3b9a61f.png) |