### PR TITLE
Replace Twitter @joeyfjj with @DangerAspect

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 DangerAspect Siege is a community-run reference site for Rainbow Six: Siege. 
 
-This site was created by [Joey](https://twitter.com/joeyfjj) to provide an easily
+This site was created by [Joey](https://twitter.com/DangerAspect) to provide an easily
 accessible site for various guides and tools for Siege. 
 
 ## Contact

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,6 +1,6 @@
 <footer>
     <p>
-        Made with ♥ by <a href="https://twitter.com/joeyfjj">@joeyfjj</a>. <a href="/about">About this site + Disclaimer</a>
+        Made with ♥ by <a href="https://twitter.com/DangerAspect">@DangerAspect</a>. <a href="/about">About this site + Disclaimer</a>
     </p>
     <p>
         This site is not affiliated with or endorsed by Ubisoft. 

--- a/about.md
+++ b/about.md
@@ -7,7 +7,7 @@ narrow-layout: true
 
 <p class="lead">DangerAspect/Siege is a community-run reference site for Rainbow Six: Siege. </p>
 
-This site was created by <a href="https://twitter.com/joeyfjj">Joey</a> to provide an easily
+This site was created by <a href="https://twitter.com/DangerAspect">Joey</a> to provide an easily
 accessible site for various guides and tools for Siege. 
 
 ## Contact


### PR DESCRIPTION
On Dec 25th, 2020, @joeyfoo you posted [this tweet](https://twitter.com/DangerAspect/status/1342594288018845696):

> ℹ Also, just a heads-up that I've (finally) migrated my Twitter username to use @DangerAspect instead of @joeyfjj! 
> 
> It probably broke some links/integrations, but at least it's consistent now!

This PR replaces all Twitter links pointing to `https://twitter.com/joeyfjj` with `https://twitter.com/DangerAspect`, so a user doesn’t have to click twice in order to visit your Twitter profile! :)